### PR TITLE
Fix identity creating for user without name

### DIFF
--- a/src/Utils/UserIdentity.php
+++ b/src/Utils/UserIdentity.php
@@ -37,7 +37,7 @@
         {
             $this->id = $userIdentity->sub;
             $this->email = $userIdentity->email;
-            $this->name = $userIdentity->name;
+            $this->name = $userIdentity->name ? $userIdentity->name : '';
             $this->username = $userIdentity->preferred_username;
             $this->roles = $userIdentity->resource_access;
         }


### PR DESCRIPTION
If user does not have a name Keycloak does not return the field. To make it backward compatible, lets use empty string as default value.

Work Item: #8